### PR TITLE
chown le faltaba unparametro

### DIFF
--- a/2-instalar-odoo.sh
+++ b/2-instalar-odoo.sh
@@ -104,7 +104,8 @@ EOF
 sudo chmod 0644 /etc/systemd/system/odoo.service
 
 sudo mkdir -p /var/opt/$odoouser/data_dir
-sudo chown -R $ODOO_USER:$ODOO_USER
+#sudo chown -R $ODOO_USER:$ODOO_USER
+sudo chown -R $ODOO_USER:$ODOO_USER /var/opt/$odoouser/data_dir
 
 sudo su - odoo -c "/usr/bin/env python3 /opt/$ODOO_USER/odoo/odoo-bin -c $CONFIG_FILE --language es_AR --load-language es_AR --init base,web,point_of_sale --data-dir /var/opt/$ODOO_USER/data_dir --without-demo all --save --db-template template1 --no-database-list --stop-after-init"
 


### PR DESCRIPTION
Me daba error al finalizar script de instalacion

 sudo chown -R $ODOO_USER:$ODOO_USER
 
chown: falta un operando después de «:»

* Supuse que había que pasarle como parámetro la carpeta que creas, inmediatamente arriba
* sudo mkdir -p /var/opt/$odoouser/data_dir
* asi que le agregué
